### PR TITLE
Update Pixel_Image_Extractor.bat

### DIFF
--- a/Pixel_Image_Extractor.bat
+++ b/Pixel_Image_Extractor.bat
@@ -3,27 +3,27 @@ title Pixel Image Extractor
 @echo off
 cls
 :GetResponse1
-	echo Step 1: copy DCIM\Camera file from phone to Desktop path: C:\Users\%username%\Desktop\Camera .(Y/N)
+	echo Step 1: Do you have both Camera folder and this batch file inside the same folder? (Y/N)
 	set /p id= "Enter Response: "
 	if /I "%id%"=="N" (
-		echo Exiting Program. Please retry after completing the pre-requisite task of copying DCIM\Camera file from phone to Desktop path: C:\Users\%username%\Desktop\Camera.
+		echo Exiting Program. Please put the folder Camera and this batch file in 1 folder and Re-run.
 		echo Killing application!
 		GOTO Kill
 	)
 	if /I "%id%"=="Y" (
-		if exist "C:\Users\%username%\Desktop\pixel_2_out" (
+		if exist "%CD%\pixel_2_out" (
 			echo Directory Exists! Deleting directory...
-			rd /s /q C:\Users\%username%\Desktop\pixel_2_out
+			rd /s /q %CD%\pixel_2_out
 			echo Directory deleted!
 		)
-			echo Creating Temp Directory pixel_2_out...
-			mkdir C:\Users\%username%\Desktop\pixel_2_out
-			echo Temp Directory pixel_2_out created.
+			echo Creating Ouput Directory pixel_2_out...
+			mkdir %CD%\pixel_2_out
+			echo Ouput Directory pixel_2_out created.
 			echo.
-			echo Copying .jpg and .mp4 files from C:\Users\%username%\Desktop\Camera to C:\Users\%username%\Desktop\pixel_2_out
+			echo Copying .jpg and .mp4 files from %CD%\Camera to %CD%\pixel_2_out
 			setlocal EnableDelayedExpansion
 			set n=0
-			for /r %%f in (*.jpg *.mp4) do set /A n+=1
+			for /r %CD%\Camera %%f in (*.jpg *.mp4) do set /A n+=1
 			echo.
 			echo    *********************************
 			echo    *  Number of files found: !n!   *
@@ -35,11 +35,11 @@ cls
 			for /L %%i in (1,1,70) do set "space=!space!"
 			set i=0
 			echo Processing files:	
-			pushd C:\Users\%username%\Desktop\Camera		
+			pushd %CD%\Camera		
 			for /r %%f in (*.jpg *.mp4) do (
 				set /A i+=1, percent=i*100/n, barLen=50*percent/100
 				for %%a in (!barLen!) do title Pixel Image Extractor !percent!%%  !bar:~0,%%a!%space%
-				COPY "%%f" "C:\Users\%username%\Desktop\pixel_2_out\%%~nxf" > nul
+				COPY "%%f" "%CD%\pixel_2_out\%%~nxf" > nul
 			)
 			popd
 			echo.
@@ -47,7 +47,18 @@ cls
 			echo    *  !i! files copied             *
 			echo    *********************************	
 			echo. 		
-			echo ******* Files extracted to C:\Users\%username%\Desktop\pixel_2_out *******
+			echo ******* Files extracted to %CD%\pixel_2_out *******
+			set /A n_after=0
+			set /A i_after=0
+			for /r %CD%\Camera %%f in (*.jpg *.mp4) do set /A n_after+=1
+			for /r %CD%\pixel_2_out %%f in (*.jpg *.mp4) do set /A i_after+=1
+			echo files in Source = !n_after!, files in destination = !i_after!
+			set /A remaining_files=!n_after!-!i_after!
+			echo ------- Matching number of files copied. ----------
+			if /A %remaining_files%==0 (
+			echo  ----------!remaining_files! files could not be copied. ----------
+			) else ( echo ------- All files copied SUCCESSFULLY. ---------- 
+			)
 			GOTO GetResponse2
 	
 	) else (
@@ -59,19 +70,19 @@ cls
 :GetResponse2
 	title Pixel Image Extractor - Completed
 	echo.
-	echo Would you like to delete the Camera directory from **Desktop** (Y/N)
+	echo Would you like to delete the Camera directory (Y/N)
 	set /p id_2= "Enter Response: "
 	if /I "%id_2%"=="Y" (
 		echo.
-		echo Deleting Camera Directory from Your Desktop...
-		rd /s/q C:\Users\%username%\Desktop\Camera
-		if exist C:\Users\%username%\Desktop\Camera rd /s /q C:\Users\%username%\Desktop\Camera
+		echo Deleting the Camera Directory...
+		rd /s/q %CD%\Camera
+		if exist %CD%\Camera rd /s /q %CD%\Camera
 		echo.
-		echo Camera Directory from Your Desktop has been deleted!
+		echo Camera Directory has been deleted!
 		GOTO End
 	) 
 	if /I "%id_2%"=="N" (
-	echo You chose not to delete Camera directory from your Desktop.
+	echo You chose not to delete the Camera directory.
 	GOTO End	
 	) else (
 	echo.
@@ -84,7 +95,7 @@ echo.
 echo Exiting Program...
 echo Opening destination directory.
 @pause
-explorer.exe C:\Users\%username%\Desktop\pixel_2_out
+explorer.exe %CD%\pixel_2_out
 Exit
 
 :Kill


### PR DESCRIPTION
* Remove hard coding for Camera folder in Desktop. .bat and the Camera folder need to be present in the same folder to work. 
* Add check for the file copied from source to destination. 
* Report if any files could not be copied.